### PR TITLE
Update CMake - Update CXX standard and xerces linking

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,9 @@ cmake_minimum_required(VERSION 3.10)
 # define project name, version
 project(PSEMolDyn_GroupE VERSION 0.0.1)
 
+# set c++ standard for the whole project
+set(CMAKE_CXX_STANDARD 14)
+
 # let ccmake and cmake-gui offer the default build type options
 set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug;Release;RelWithDebInfo;MinSizeRel")
 
@@ -44,6 +47,8 @@ FetchContent_MakeAvailable(spdlog)
 # default log level is info, but the user can override it
 set(LOG_LEVEL "info" CACHE STRING "Set log level (default: info)")
 
+# Find xerces as a package
+find_package(XercesC REQUIRED)
 
 enable_testing()
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -27,12 +27,6 @@ target_link_libraries(MolSimLib
 # create make target
 add_executable(MolSim MolSim.cpp)
 
-# set cxx standard. You may raise this if you want.
-target_compile_features(MolSim
-        PRIVATE
-        cxx_std_17
-)
-
 target_include_directories(MolSim
         PUBLIC
         ${CMAKE_SOURCE_DIR}/libs/libxsd

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -11,6 +11,7 @@ add_library(MolSimLib ${MY_SRC})
 
 target_include_directories(MolSimLib
         PUBLIC
+        ${XercesC_INCLUDE_DIRS}
         ${CMAKE_SOURCE_DIR}/libs/libxsd
         PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}
@@ -19,7 +20,7 @@ target_include_directories(MolSimLib
 target_link_libraries(MolSimLib
         # stuff that is used in headers and source files
         PUBLIC
-        xerces-c
+        ${XercesC_LIBRARY}
         spdlog::spdlog
 )
 

--- a/src/Containers/ParticleContainerBase.h
+++ b/src/Containers/ParticleContainerBase.h
@@ -23,7 +23,16 @@ protected:
     ForceBase& forceModel;
 
 public:
+    /**
+     * Abstract base class for all particle containers.
+     * @param model Force model to be used for calculating forces on all particles.
+     */
     ParticleContainerBase(ForceBase& model) : forceModel(model) {}
+
+    /**
+     * Default Destructor
+     */
+    virtual ~ParticleContainerBase() = default;
 
     /**
      * Add a particle to the container.


### PR DESCRIPTION
Updated CMakeLists should work for both Linux and MacOs.
It is inspired by Group F. I think they also have a Mac user.